### PR TITLE
Fix Linux >=5.6 and fix C90 compiler warnings

### DIFF
--- a/cartographer.c
+++ b/cartographer.c
@@ -257,8 +257,8 @@ static struct proc_ops file_ops = {
 };
 #else
 static struct file_operations file_ops = {
-    .owner = THIS_MODULE;
-    .write = on_write;
+    .owner = THIS_MODULE,
+    .write = on_write,
 };
 #endif
 

--- a/cartographer.c
+++ b/cartographer.c
@@ -90,6 +90,10 @@ static asmlinkage void (*orig_show_map_vma)(struct seq_file *m,
 static asmlinkage void cart_show_map_vma(struct seq_file *m,
                                          struct vm_area_struct *vma)
 {
+
+    struct file *file_backup;
+    unsigned long backup_flags;
+
     if( !vma || !vma->vm_file ) {
         return orig_show_map_vma( m, vma );
     }
@@ -99,8 +103,8 @@ static asmlinkage void cart_show_map_vma(struct seq_file *m,
         return orig_show_map_vma( m, vma );
     }
 
-    struct file *file_backup = vma->vm_file;
-    unsigned long backup_flags = vma->vm_flags;
+    file_backup = vma->vm_file;
+    backup_flags = vma->vm_flags;
 
     if( settings.remove_entry ){ // in some cases the memory offset makes this kinda obvious, but it seems there's gaps naturally too sometimes.
         cart_print("show_map_vma Hook - removing entry in maps (%s)\n", vma->vm_file->f_path.dentry->d_iname);
@@ -131,6 +135,7 @@ static ssize_t on_write(struct file *file, const char *buf, size_t len, loff_t *
 {
     u8 res; //perms
     int err;
+    char *backup, *word;
 
     /* not sure if this mutex is needed. */
     mutex_lock(&data_mutex);
@@ -140,7 +145,7 @@ static ssize_t on_write(struct file *file, const char *buf, size_t len, loff_t *
         goto end;
     }
     /* strsep changes the string, buf is constant, need to copy */
-    char *backup = kmalloc(len, GFP_KERNEL);
+    backup = kmalloc(len, GFP_KERNEL);
     if( !backup ){
         cart_print("Failed to malloc %ld bytes for argument parsing!\n", len);
         goto end;
@@ -152,7 +157,7 @@ static ssize_t on_write(struct file *file, const char *buf, size_t len, loff_t *
     }
     backup[len - 1] = '\0';
     /* Get First word for command */
-    char *word = strsep( &backup, " ,\n\t" );
+    word = strsep( &backup, " ,\n\t" );
     if( strstr(word, "settarget") ){
         word = strsep( &backup, " ,\n\t" );
         if( !word ){
@@ -271,6 +276,8 @@ static int on_each_symbol(void *data, const char *name,
 }
 static int cart_startup(void)
 {
+   int ret;
+   struct proc_dir_entry *entry;
 
     if( !kallsyms_on_each_symbol( on_each_symbol, "show_map_vma" ) ){
         cart_print( "Error iterating through modules!\n" );
@@ -283,7 +290,7 @@ static int cart_startup(void)
     //show_map_vma_hook.name = "show_map_vma";
     show_map_vma_hook.function = cart_show_map_vma;
     show_map_vma_hook.original = &orig_show_map_vma;
-    int ret = init_hook( &show_map_vma_hook );
+    ret = init_hook( &show_map_vma_hook );
 
     if( ret )
         return ret;
@@ -306,7 +313,7 @@ static int cart_startup(void)
         return ret;
     }
 
-    struct proc_dir_entry *entry = proc_create(PROC_FILENAME, 0, NULL, &file_ops);
+    entry = proc_create(PROC_FILENAME, 0, NULL, &file_ops);
     if( !entry ){
         cart_print("proc_create failed! is NULL\nUnload and try again!\n");
         return -EUCLEAN;


### PR DESCRIPTION
This PR adds a macro to check for kernel version, and if greater than or equal to 5.6.0, uses proc_ops instead of file_operations as the latter has been deprecated.
Additionally I moved all variable instantiation before assignment to get rid of the C90 warnings from the compiler.
I put both of these in one PR since fixing the compiler warnings was trivial, hope that's OK.
